### PR TITLE
Fix drag and drop tasks

### DIFF
--- a/src/Gantt.svelte
+++ b/src/Gantt.svelte
@@ -1,4 +1,7 @@
 <script>
+    import * as moment_ from 'moment';
+    const moment = moment_
+        
     import { onMount, setContext, tick, onDestroy } from 'svelte';
     import { writable, derived } from 'svelte/store';
 

--- a/src/entities/Task.svelte
+++ b/src/entities/Task.svelte
@@ -83,13 +83,13 @@
 
                 const changed = !prevFrom.isSame(newFrom) || !prevTo.isSame(newTo) || (sourceRow && sourceRow.model.id !== targetRow.model.id);
                 if(changed) {
-                    gantt.api.tasks.raise.change({ task: newTask, sourceRow, targetRow });
+                    api.tasks.raise.change({ task: newTask, sourceRow, targetRow });
                 }
 
                 taskStore.update(newTask);
 
                 if(changed) {
-                    gantt.api.tasks.raise.changed({ task: newTask, sourceRow, targetRow });
+                    api.tasks.raise.changed({ task: newTask, sourceRow, targetRow });
                 }
 
                 // update shadow tasks

--- a/tools/build.js
+++ b/tools/build.js
@@ -46,7 +46,7 @@ promise = promise.then(() => rollup.rollup({
             moment: 'moment'
         },
         extend: format === 'iife',
-		name: format === 'iife' ? 'window' : undefined // pkg.name : undefined,
+		name: format === 'iife' ? 'window' : pkg.name // pkg.name : undefined,
 	}));
 });
 


### PR DESCRIPTION
Hello again :)

With the latest npm build maybe because of one merge, some code as gantt.api.tasks.raise.change, I changed to api.tasks.raise.change only.

The function getDateByPosition was missing the moment import, because this project uses typescript and rollup, I found a workaround to import that.
`
 import * as moment_ from 'moment';
 const moment = moment_
`
[Source](https://github.com/jvandemo/generator-angular2-library/issues/221#issuecomment-516445049)

I tested and that changes fixes the errors, but see by yourself if it is a good resolution. Thank you.
