### PR TITLE
Correct documentation for deprecated enableDragging and enableResize

### DIFF
--- a/packages/docs-mdsvex/src/routes/docs/data/rows/+page.svx
+++ b/packages/docs-mdsvex/src/routes/docs/data/rows/+page.svx
@@ -18,10 +18,10 @@ Rows are defined as a list of objects. Rows can be rendered as a collapsible tre
 `id` | `number &#124; string` | Id of row, every row needs to have a unique one. **(required)**
 `classes` | `string &#124; string[]` | Custom CSS classes to apply to row.
 `contentHtml` | `string` | Html content of row, renders as background to a row.
-`enableDragging` | `boolean` | enable dragging of tasks to and from this row. | `true`
-`draggable` | `boolean` | enable dragging of tasks to and from this row. *(deprecated)* | `true`
-`enableResize` | `boolean` | enable resize of tasks on this row. | `true`
-`resizable` | `boolean` | enable resize of tasks on this row. *(deprecated)* | `true`
+`enableDragging` | `boolean` | enable dragging of tasks to and from this row. *(deprecated)* | `true`
+`draggable` | `boolean` | enable dragging of tasks to and from this row. | `true`
+`enableResize` | `boolean` | enable resize of tasks on this row. *(deprecated)* | `true`
+`resizable` | `boolean` | enable resize of tasks on this row. | `true`
 `label` | `string` | Label of row, could be any other property, can be displayed with SvelteGanttTable.
 `headerHtml` | `string` | Html content of table row header, displayed in SvelteGanttTable.
 `children` | `object[]` | List of children row objects, these can have their own children.


### PR DESCRIPTION
I think this was just a goof when things got refactored. I appreciate the attention to detail and tidying things up so that `draggable` and `resizable` are consistent in this library!